### PR TITLE
fix: Disable building of XC Atlantis container

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ jobs:
   release:
     name: Build and push XC atlantis image to registries
     runs-on: ubuntu-latest
+    # TODO: @memes haven't used Atlantis on RE nodes for a long time remove?
+    if: false
     steps:
       - name: Checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
The module is not under active development, so building the container on every release is a waste. May remove entirely later.